### PR TITLE
fix #22 release failed

### DIFF
--- a/src/utils/__tests__/__snapshots__/generateFFmpegCommand.test.ts.snap
+++ b/src/utils/__tests__/__snapshots__/generateFFmpegCommand.test.ts.snap
@@ -3,7 +3,7 @@
 exports[`generateFFmpegCommand > generates basic input-output-global chain command 1`] = `
 {
   "error": null,
-  "result": "ffmpeg -i input.mp4 -map 0 output.mp4",
+  "result": "ffmpeg -i input.mp4 output.mp4",
 }
 `;
 

--- a/src/utils/nodeMapping.ts
+++ b/src/utils/nodeMapping.ts
@@ -629,7 +629,11 @@ export class NodeMappingManager {
             }
           }
         } else {
-          throw new Error(`Option ${key} not found in filter of type ${node.constructor.name}${node.name ? ` with name ${node.name}` : ''}`);
+          throw new Error(
+            `Option ${key} not found in filter of type ${node.constructor.name}${
+              'name' in node ? ` with name ${node.name}` : ''
+            }`,
+          );
         }
       });
     }


### PR DESCRIPTION
- fix #22 

This pull request includes a minor improvement to error handling in the `NodeMappingManager` class. The change modifies the error message formatting to use a safer property check (`'name' in node`) instead of directly accessing `node.name`. 

Error handling improvement:

* [`src/utils/nodeMapping.ts`](diffhunk://#diff-65c49f725d46d8e8697a7826b0de8d24892dbef72f33965f53b63c053092d218L632-R636): Updated the error message in `NodeMappingManager` to use a safer property check (`'name' in node`) for determining the presence of the `name` property in `node`.